### PR TITLE
Alterações README e import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # send-gmail
 Enviando gmail com Python
 
-
-Para rodar basta fazer um Git Clone e em seguida rodar "pip install -r requirements.txt"
+Para rodar basta fazer um Git Clone e em seguida rodar "python3 send-gmail.py"

--- a/send-gmail.py
+++ b/send-gmail.py
@@ -1,9 +1,8 @@
-import json 
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import smtplib
 
-# Corpo da mensagem do email #
+# Corpo da mensagem do email 
 msg = MIMEMultipart()
 message = "Você recebeu um email da Pycodebr :)"
 


### PR DESCRIPTION
- Para o seguinte código não é necessário executar o comando "pip install -r requirements.txt" pois as bibliotecas usadas para mandar o e-mail são nativas do próprio Python. Alterei a orientação contida no README "rodar pip install -r requirements.txt" por "rodar python3 send-gmail.py"
- Para complementar no código removi o "import json" visto que a biblioteca json não é utilizada no código.

- Abraços.